### PR TITLE
Add run test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /target
+/test_target
 /cloned_*
 /*.out
 /*.profraw
 /*.profdata
+/.IS_ECEPROG

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
-/cloned_repo
+/cloned_*
+/*.out
+/*.profraw
+/*.profdata

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.3"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d93d855ce6a0aa87b8473ef9169482f40abaa2e9e0993024c35c902cbd5920"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -444,9 +444,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ git2 = "0.16.1"
 statrs = "0.16.0"
 chrono = "0.4.23"
 assert_cmd = "2.0.8"
+clap = { version = "4.1.4", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.1.3", features = ["derive"] }
 env_logger = "0.10.0"
 log = "0.4.17"
 reqwest = { version = "0.11.14", features = ["blocking", "json"] }

--- a/run
+++ b/run
@@ -18,6 +18,10 @@ else
 fi
 
 if [[ "$1" == "build" ]]; then
+    if [[ -f .IS_ECEPROG ]]; then
+        . ~/.cargo/env
+    fi
+
     # build program
     cargo build
 elif [[ "$1" == "install" ]]; then
@@ -27,6 +31,7 @@ elif [[ "$1" == "install" ]]; then
 	bash rustup_install.sh -y --no-modify-path
 	source ~/.cargo/env
 	rm -f rustup_install.sh
+	touch .IS_ECEPROG
     fi
 
     # install test dependencies
@@ -35,6 +40,10 @@ elif [[ "$1" == "install" ]]; then
         cargo install cargo-binutils
     fi
 elif [[ "$1" == "test" ]]; then
+    if [[ -f .IS_ECEPROG ]]; then
+        . ~/.cargo/env
+    fi
+
     # check for github token
     if [[ "$GITHUB_TOKEN" == "" ]]; then
         echo "Please supply \$GITHUB_TOKEN for the correct test result"
@@ -49,6 +58,7 @@ elif [[ "$1" == "test" ]]; then
     rm -f test_result.out
     rm -f test_result.temp
     rm -f line_result.out
+    rm -rf ./test_target
 
     # run tests
     RUSTFLAGS="-C instrument-coverage" cargo build --target-dir="test_target"
@@ -90,7 +100,20 @@ elif [[ "$1" == "test" ]]; then
         > ./line_result.out
 
     "$EXE" report ./test_result.out ./line_result.out
+
+    rm -f *.profraw
+    rm -f *.profdata
+    rm -f cargo_test.out
+    rm -f test_exes.txt
+    rm -f test_result.out
+    rm -f test_result.temp
+    rm -f line_result.out
+    rm -rf ./test_target
 else
+    if [[ -f .IS_ECEPROG ]]; then
+        . ~/.cargo/env
+    fi
+
     # parse url file
     "$EXE" url $1
 fi

--- a/run
+++ b/run
@@ -45,11 +45,13 @@ elif [[ "$1" == "test" ]]; then
     rm -f *.profraw
     rm -f *.profdata
     rm -f cargo_test.out
+    rm -f test_exes.txt
     rm -f test_result.out
     rm -f test_result.temp
     rm -f line_result.out
 
     # run tests
+    RUSTFLAGS="-C instrument-coverage" cargo build --target-dir="test_target"
     RUSTFLAGS="-C instrument-coverage" cargo test --tests --message-format=json --no-run ece461_team19_cli > cargo_test.out
     grep '"executable":".*/deps/' cargo_test.out | sed 's/.*"executable":"\([^"]*\)".*/\1/' > test_exes.txt
     while IFS="" read -r line
@@ -57,18 +59,36 @@ elif [[ "$1" == "test" ]]; then
         "$line" --logfile=./test_result.temp
         cat ./test_result.temp >> ./test_result.out
     done < test_exes.txt
-    exit
 
     # merge coverage data
     "$LLVM_PROFDATA" merge -sparse *.profraw -o line_result.profdata
-    "$LLVM_COV" export -format=text -summary-only "$TEST_EXE" \
+
+    # process test result
+    if [[ "$2" == "show" ]]; then
+        "$LLVM_COV" show -Xdemangler=rustfilt \
+            $(while IFS="" read -r line; \
+                do \
+                    printf "%s %s " "--object" $line; \
+                done < test_exes.txt \
+            ) \
+            --object ./test_target/debug/ece461_team19_cli \
+            --instr-profile=line_result.profdata \
+            --ignore-filename-regex=/.cargo/registry \
+            --ignore-filename-regex=/rustc
+    fi
+
+    "$LLVM_COV" export -format=text -summary-only \
+        $(while IFS="" read -r line; \
+            do \
+                printf "%s %s " "--object" $line; \
+            done < test_exes.txt \
+        ) \
+        --object ./test_target/debug/ece461_team19_cli \
         --instr-profile=line_result.profdata \
         --ignore-filename-regex=/.cargo/registry \
         --ignore-filename-regex=/rustc \
         > ./line_result.out
 
-    # process test result
-    [[ -f "$EXE" ]] || "$0" build
     "$EXE" report ./test_result.out ./line_result.out
 else
     # parse url file

--- a/run
+++ b/run
@@ -23,19 +23,20 @@ elif [[ "$1" == "test" ]]; then
     rm -f line_result.out
 
     # run tests
-    RUSTFLAGS="-C instrument-coverage" cargo test --tests --message-format=json --no-run > cargo_test.out
+    RUSTFLAGS="-C instrument-coverage" cargo test --tests --message-format=json --no-run ece461_team19_cli > cargo_test.out
     TEST_EXE=$(tail -2 cargo_test.out | head -1 | sed 's/.*"executable":"\([^"]*\)".*/\1/')
-    $TEST_EXE --logfile=./test_result.out
+    "$TEST_EXE" --logfile=./test_result.out
 
     # merge coverage data
     rust-profdata merge -sparse *.profraw -o line_result.profdata
-    rust-cov export -format=text -summary-only $TEST_EXE \
+    rust-cov export -format=text -summary-only "$TEST_EXE" \
         --instr-profile=line_result.profdata \
         --ignore-filename-regex=/.cargo/registry \
         --ignore-filename-regex=/rustc \
         > ./line_result.out
 
     # process test result
+    [[ -f "$EXE" ]] || "$0" build
     "$EXE" report ./test_result.out ./line_result.out
 else
     # parse url file

--- a/run
+++ b/run
@@ -21,6 +21,14 @@ if [[ "$1" == "build" ]]; then
     # build program
     cargo build
 elif [[ "$1" == "install" ]]; then
+    # install newer rust
+    if ! [ -x "$(command -v rustup)" ]; then
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup_install.sh
+	bash rustup_install.sh -y --no-modify-path
+	source ~/.cargo/env
+	rm -f rustup_install.sh
+    fi
+
     # install test dependencies
     if ! [ -x "$(command -v llvm-profdata-14)" ]; then
         rustup component add llvm-tools-preview

--- a/run
+++ b/run
@@ -5,14 +5,16 @@ set -e
 
 EXE="./target/debug/ece461_team19_cli"
 
-if [ -x "$(command -v rustup)" ]; then
-    # use rustup to install llvm tools
-    LLVM_COV="rust-cov"
-    LLVM_PROFDATA="rust-profdata"
-else
-    # assume we are on eceprog
+# check for existing llvm tools
+if [ -x "$(command -v llvm-cov-14)" ]; then
     LLVM_COV="llvm-cov-14"
+else
+    LLVM_COV="rust-cov"
+fi
+if [ -x "$(command -v llvm-profdata-14)" ]; then
     LLVM_PROFDATA="llvm-profdata-14"
+else
+    LLVM_PROFDATA="rust-profdata"
 fi
 
 if [[ "$1" == "build" ]]; then
@@ -20,7 +22,7 @@ if [[ "$1" == "build" ]]; then
     cargo build
 elif [[ "$1" == "install" ]]; then
     # install test dependencies
-    if [ -x "$(command -v rustup)" ]; then
+    if ! [ -x "$(command -v llvm-profdata-14)" ]; then
         rustup component add llvm-tools-preview
         cargo install cargo-binutils
     fi

--- a/run
+++ b/run
@@ -9,8 +9,34 @@ elif [[ "$1" == "install" ]]; then
     # TODO list of dependencies to install
     echo "install what"
 elif [[ "$1" == "test" ]]; then
-    # TODO generate test reports
-    "$EXE" report some_report_file.profdata
+    # check for github token
+    if [[ "$GITHUB_TOKEN" == "" ]]; then
+        echo "Please supply \$GITHUB_TOKEN for the correct test result"
+        exit
+    fi
+
+    # remove files of previous tests
+    rm -f *.profraw
+    rm -f *.profdata
+    rm -f cargo_test.out
+    rm -f test_result.out
+    rm -f line_result.out
+
+    # run tests
+    RUSTFLAGS="-C instrument-coverage" cargo test --tests --message-format=json --no-run > cargo_test.out
+    TEST_EXE=$(tail -2 cargo_test.out | head -1 | sed 's/.*"executable":"\([^"]*\)".*/\1/')
+    $TEST_EXE --logfile=./test_result.out
+
+    # merge coverage data
+    rust-profdata merge -sparse *.profraw -o line_result.profdata
+    rust-cov export -format=text -summary-only $TEST_EXE \
+        --instr-profile=line_result.profdata \
+        --ignore-filename-regex=/.cargo/registry \
+        --ignore-filename-regex=/rustc \
+        > ./line_result.out
+
+    # process test result
+    "$EXE" report ./test_result.out ./line_result.out
 else
     # parse url file
     "$EXE" url $1

--- a/run
+++ b/run
@@ -6,8 +6,9 @@ if [[ "$1" == "build" ]]; then
     # build program
     cargo build
 elif [[ "$1" == "install" ]]; then
-    # TODO list of dependencies to install
-    echo "install what"
+    # install test dependencies
+    rustup component add llvm-tools-preview
+    cargo install cargo-binutils
 elif [[ "$1" == "test" ]]; then
     # check for github token
     if [[ "$GITHUB_TOKEN" == "" ]]; then

--- a/run
+++ b/run
@@ -46,12 +46,18 @@ elif [[ "$1" == "test" ]]; then
     rm -f *.profdata
     rm -f cargo_test.out
     rm -f test_result.out
+    rm -f test_result.temp
     rm -f line_result.out
 
     # run tests
     RUSTFLAGS="-C instrument-coverage" cargo test --tests --message-format=json --no-run ece461_team19_cli > cargo_test.out
-    TEST_EXE=$(tail -2 cargo_test.out | head -1 | sed 's/.*"executable":"\([^"]*\)".*/\1/')
-    "$TEST_EXE" --logfile=./test_result.out
+    grep '"executable":".*/deps/' cargo_test.out | sed 's/.*"executable":"\([^"]*\)".*/\1/' > test_exes.txt
+    while IFS="" read -r line
+    do
+        "$line" --logfile=./test_result.temp
+        cat ./test_result.temp >> ./test_result.out
+    done < test_exes.txt
+    exit
 
     # merge coverage data
     "$LLVM_PROFDATA" merge -sparse *.profraw -o line_result.profdata

--- a/run
+++ b/run
@@ -2,13 +2,25 @@
 
 EXE="./target/debug/ece461_team19_cli"
 
+if [ -x "$(command -v rustup)" ]; then
+    # use rustup to install llvm tools
+    LLVM_COV="rust-cov"
+    LLVM_PROFDATA="rust-profdata"
+else
+    # assume we are on eceprog
+    LLVM_COV="llvm-cov-14"
+    LLVM_PROFDATA="llvm-profdata-14"
+fi
+
 if [[ "$1" == "build" ]]; then
     # build program
     cargo build
 elif [[ "$1" == "install" ]]; then
     # install test dependencies
-    rustup component add llvm-tools-preview
-    cargo install cargo-binutils
+    if [ -x "$(command -v rustup)" ]; then
+        rustup component add llvm-tools-preview
+        cargo install cargo-binutils
+    fi
 elif [[ "$1" == "test" ]]; then
     # check for github token
     if [[ "$GITHUB_TOKEN" == "" ]]; then
@@ -29,8 +41,8 @@ elif [[ "$1" == "test" ]]; then
     "$TEST_EXE" --logfile=./test_result.out
 
     # merge coverage data
-    rust-profdata merge -sparse *.profraw -o line_result.profdata
-    rust-cov export -format=text -summary-only "$TEST_EXE" \
+    "$LLVM_PROFDATA" merge -sparse *.profraw -o line_result.profdata
+    "$LLVM_COV" export -format=text -summary-only "$TEST_EXE" \
         --instr-profile=line_result.profdata \
         --ignore-filename-regex=/.cargo/registry \
         --ignore-filename-regex=/rustc \

--- a/run
+++ b/run
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# exit on error
+set -e
+
 EXE="./target/debug/ece461_team19_cli"
 
 if [ -x "$(command -v rustup)" ]; then

--- a/src/file_parser.rs
+++ b/src/file_parser.rs
@@ -1,0 +1,25 @@
+// parse test output produced by test script generated with `./run test`
+// returns (total tests, tests passed)
+pub fn test_cases(filename: &str) -> Option<(u32, u32)> {
+    let file = std::fs::read_to_string(filename).ok()?;
+    let lines = file.lines();
+
+    let mut tests = 0;
+    let mut passed = 0;
+    for l in lines {
+        tests += 1;
+        if let Some("ok") = l.split(' ').next() {
+            passed += 1;
+        }
+    }
+
+    Some((tests, passed))
+}
+
+// parse line coverage output produced by test script generated with `./run test`
+// returns percentage of lines tested
+pub fn code_coverage(filename: &str) -> Option<f64> {
+    let file = std::fs::read_to_string(filename).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&file).ok()?;
+    json["data"][0]["totals"]["lines"]["percent"].as_f64()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod file_parser;
 mod metrics;
 
 use clap::{Parser, Subcommand};
@@ -22,7 +23,10 @@ enum Commands {
     Url { url_file: String },
 
     /// Parse results of tests
-    Report { report_file: String },
+    Report {
+        test_result: String,
+        line_analysis: String,
+    },
 }
 
 fn main() -> Result<(), String> {
@@ -66,7 +70,17 @@ fn main() -> Result<(), String> {
 
     match &cli.command {
         Commands::Url { url_file: f } => calcscore(f)?, //println!("url: {:?}", f),
-        Commands::Report { report_file: f } => println!("test: {:?}", f),
+        Commands::Report {
+            test_result: t,
+            line_analysis: l,
+        } => {
+            let (tests, passed) = file_parser::test_cases(t).unwrap();
+            let coverage = file_parser::code_coverage(l).unwrap();
+            println!(
+                "{}/{} test cases passed. {:.2}% line coverage achieved.",
+                passed, tests, coverage
+            )
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,6 @@ fn main() -> Result<(), String> {
 
     // parse command line arguments
     let cli = Cli::parse();
-
     match &cli.command {
         Commands::Url { url_file: f } => calcscore(f)?, //println!("url: {:?}", f),
         Commands::Report {

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,9 @@ fn main() -> Result<(), String> {
         } => {
             let (tests, passed) = file_parser::test_cases(t).unwrap();
             let coverage = file_parser::code_coverage(l).unwrap();
+            println!("Total: {}", tests);
+            println!("Passed: {}", passed);
+            println!("Coverage: {:.0}%", coverage);
             println!(
                 "{}/{} test cases passed. {:.2}% line coverage achieved.",
                 passed, tests, coverage

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,35 +1,39 @@
 use assert_cmd::Command;
 
+fn get_bin() -> Command {
+    Command::new("./test_target/debug/ece461_team19_cli")
+}
+
 #[test]
 fn working() {}
 
 #[test]
 fn no_arguments() {
-    let mut cmd = Command::cargo_bin("ece461_team19_cli").unwrap();
+    let mut cmd = get_bin();
     cmd.assert().failure();
 }
 
 #[test]
 fn bad_arguments() {
-    let mut cmd1 = Command::cargo_bin("ece461_team19_cli").unwrap();
+    let mut cmd1 = get_bin();
     cmd1.arg("what").assert().failure();
 
-    let mut cmd2 = Command::cargo_bin("ece461_team19_cli").unwrap();
+    let mut cmd2 = get_bin();
     cmd2.arg("url").assert().failure();
 
-    let mut cmd3 = Command::cargo_bin("ece461_team19_cli").unwrap();
+    let mut cmd3 = get_bin();
     cmd3.arg("report").assert().failure();
 }
 
 #[test]
 fn bad_file_name() {
-    let mut cmd = Command::cargo_bin("ece461_team19_cli").unwrap();
+    let mut cmd = get_bin();
     cmd.args(["url", "notafile.osu"]).assert().failure();
 }
 
 #[test]
 fn empty_file() {
-    let mut cmd = Command::cargo_bin("ece461_team19_cli").unwrap();
+    let mut cmd = get_bin();
     cmd.args(["url", "tests/empty.txt"])
         .assert()
         .success()
@@ -38,7 +42,7 @@ fn empty_file() {
 
 #[test]
 fn new_lines() {
-    let mut cmd = Command::cargo_bin("ece461_team19_cli").unwrap();
+    let mut cmd = get_bin();
     cmd.args(["url", "tests/newline.txt"])
         .assert()
         .success()
@@ -47,12 +51,12 @@ fn new_lines() {
 
 #[test]
 fn bad_url() {
-    let mut cmd = Command::cargo_bin("ece461_team19_cli").unwrap();
+    let mut cmd = get_bin();
     cmd.args(["url", "tests/badurl.txt"]).assert().failure();
 }
 
 #[test]
 fn good_urls() {
-    let mut cmd = Command::cargo_bin("ece461_team19_cli").unwrap();
+    let mut cmd = get_bin();
     cmd.args(["url", "tests/url.txt"]).assert().success();
 }


### PR DESCRIPTION
implemented `./run test`, and added dependencies for `./run install`.

Sample output: `3/3 test cases passed. 48.72% line coverage achieved.`

There is currently no official way to test this on eceprog, so lets wait until wednesday to see if there's any progress on eceprog before merging this. (piazza question 92)